### PR TITLE
constrain QC version, closes #1

### DIFF
--- a/Checkers.cabal
+++ b/Checkers.cabal
@@ -27,7 +27,7 @@ source-repository head
 Library
   hs-Source-Dirs:      src
   Extensions:
-  Build-Depends:       base < 5, random, QuickCheck>=2.3, array >= 0.1
+  Build-Depends:       base < 5, random, QuickCheck>=2.3 && <2.7, array >= 0.1
   Exposed-Modules:     
                        Test.QuickCheck.Utils
                        Test.QuickCheck.Checkers


### PR DESCRIPTION
constraining upper bound of QC to restore buildability, obviously only a stopgap.
