### PR TITLE
Re-import some things to be compatible with old GHCs.

### DIFF
--- a/src/Test/QuickCheck/Checkers.hs
+++ b/src/Test/QuickCheck/Checkers.hs
@@ -43,8 +43,8 @@ module Test.QuickCheck.Checkers
   , arbitrarySatisfying
   ) where
 
--- import Data.Function (on)
 import Data.Function (on)
+import Data.Monoid (Monoid (mempty, mappend))
 import Control.Applicative
 import Control.Arrow ((***),first)
 import qualified Control.Exception as Ex

--- a/src/Test/QuickCheck/Classes.hs
+++ b/src/Test/QuickCheck/Classes.hs
@@ -28,6 +28,7 @@ module Test.QuickCheck.Classes
   )
   where
 
+import Control.Applicative ((<$>))
 import Data.Foldable (foldMap)
 import Data.Functor.Apply (Apply ((<.>)))
 import Data.Functor.Alt (Alt ((<!>)))

--- a/src/Test/QuickCheck/Instances/Array.hs
+++ b/src/Test/QuickCheck/Instances/Array.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_GHC -Wall -fno-warn-orphans #-}
 module Test.QuickCheck.Instances.Array where
 
+import Control.Applicative ((<$>))
 import Test.QuickCheck
 import Data.Array
 

--- a/src/Test/QuickCheck/Instances/Maybe.hs
+++ b/src/Test/QuickCheck/Instances/Maybe.hs
@@ -1,5 +1,6 @@
 module Test.QuickCheck.Instances.Maybe (maybeGen) where
 
+import Control.Applicative (pure, (<$>))
 import Test.QuickCheck
 
 maybeGen :: Gen a -> Gen (Maybe a)

--- a/src/Test/QuickCheck/Instances/Num.hs
+++ b/src/Test/QuickCheck/Instances/Num.hs
@@ -4,6 +4,7 @@ module Test.QuickCheck.Instances.Num
        ,nonZero,nonZero_
        ) where
 
+import Control.Applicative ((<$>))
 import Test.QuickCheck
 import Control.Monad.Extensions
 


### PR DESCRIPTION
<$> and Monoid are not in Prelude in older GHCs.

The import cleaning broke some builds on older GHCs: https://matrix.hackage.haskell.org/package/checkers

Please make hackage metadata revisions for checkers versions 0.4.8 and 0.4.9 to add a lower bound of base >= 4.8 so that a build will fail gracefully on GHC < 7.10

Then please merge this pull request and release 0.4.9.1, which should build at least as far back as 7.4
https://travis-ci.org/gwils/checkers/builds/295110835