### PR TITLE
Fix simplifiable-class-constraints warning on GHC 8.2.1

### DIFF
--- a/src/Test/QuickCheck/Classes.hs
+++ b/src/Test/QuickCheck/Classes.hs
@@ -134,7 +134,8 @@ functorMonoid :: forall m a b.
   ( Functor m
   , Monoid (m a)
   , Monoid (m b)
-  , Arbitrary (a->b)
+  , CoArbitrary a
+  , Arbitrary b
   , Arbitrary (m a)
   , Show (m a)
   , EqProp (m b)) =>


### PR DESCRIPTION
```
src/Test/QuickCheck/Classes.hs:133:18:` warning: [-Wsimplifiable-class-constraints]
    • The constraint ‘Arbitrary (a -> b)’
        matches an instance declaration
      instance (CoArbitrary a, Arbitrary b) => Arbitrary (a -> b)
        -- Defined in ‘Test.QuickCheck.Arbitrary’
      This makes type inference for inner bindings fragile;
        either use MonoLocalBinds, or simplify it using the instance
    • In the type signature:
        functorMonoid :: forall m a b.
                         (Functor m,
                          Monoid (m a),
                          Monoid (m b),
                          Arbitrary (a -> b),
                          Arbitrary (m a),
                          Show (m a),
                          EqProp (m b)) =>
                         m (a, b) -> TestBatch
```