### PR TITLE
Provide a value for homepage

### DIFF
--- a/checkers.cabal
+++ b/checkers.cabal
@@ -20,7 +20,7 @@ License-File:        COPYING
 Stability:           experimental
 build-type:          Simple
 tested-with:         GHC==8.2.1, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
-
+homepage:            https://github.com/conal/checkers
 source-repository head
   type:     git
   location: git://github.com/conal/checkers.git


### PR DESCRIPTION
Nice to have thing for when this is published to hackage, you can click a link directly to the gihub repo rather than munging the git url.