### PR TITLE
Include Applicative-Monad relationship in Monad laws

### DIFF
--- a/src/Test/QuickCheck/Classes.hs
+++ b/src/Test/QuickCheck/Classes.hs
@@ -429,22 +429,29 @@ monad :: forall m a b c.
          , Arbitrary (m a), EqProp (m a), Show (m a)
          , Arbitrary (m b), EqProp (m b)
          , Arbitrary (m c), EqProp (m c)
+         , Show (m (a -> b)), Arbitrary (m (a -> b))
          ) =>
          m (a,b,c) -> TestBatch
 monad = const ( "monad laws"
               , [ ("left  identity", property leftP)
                 , ("right identity", property rightP)
                 , ("associativity" , property assocP)
+                , ("pure", property pureP)
+                , ("ap", property apP)
                 ]
               )
  where
    leftP  :: (a -> m b) -> a -> Property
    rightP :: m a -> Property
    assocP :: m a -> (a -> m b) -> (b -> m c) -> Property
+   pureP :: a -> Property
+   apP :: m (a -> b) -> m a -> Property
 
    leftP f a    = (return a >>= f)  =-= f a
    rightP m     = (m >>= return)    =-=  m
    assocP m f g = ((m >>= f) >>= g) =-= (m >>= (\x -> f x >>= g))
+   pureP x = (pure x :: m a) =-= return x
+   apP f x = (f <*> x) =-= (f `ap` x)
 
 -- | Law for monads that are also instances of 'Functor'.
 monadFunctor :: forall m a b.


### PR DESCRIPTION
I think this makes sense since Applicative has become a superclass of Monad.

What about `monadApplicative` though, which is somewhat redundant now? Deprecate it?

(The same can be asked about `monadFunctor`. And `applicative` already contains the Functor-Applicative relationship.)

`bindApply` should probably be handled in the same way as `monadApplicative`.