### PR TITLE
semigroup: Add checks for sconcat and stimes

### DIFF
--- a/checkers.cabal
+++ b/checkers.cabal
@@ -42,6 +42,7 @@ Library
                        Test.QuickCheck.Instances.Eq
                        Test.QuickCheck.Instances.List
                        Test.QuickCheck.Instances.Maybe
+                       Test.QuickCheck.Instances.NonEmpty
                        Test.QuickCheck.Instances.Num
                        Test.QuickCheck.Instances.Ord
                        Test.QuickCheck.Instances.Tuple

--- a/src/Test/QuickCheck/Instances/NonEmpty.hs
+++ b/src/Test/QuickCheck/Instances/NonEmpty.hs
@@ -1,0 +1,12 @@
+{-# OPTIONS_GHC -Wall -fno-warn-orphans #-}
+module Test.QuickCheck.Instances.NonEmpty where
+
+import Control.Applicative
+import Data.List.NonEmpty
+import Test.QuickCheck
+
+instance Arbitrary a => Arbitrary (NonEmpty a) where
+  arbitrary = liftA2 (:|) arbitrary arbitrary
+
+instance CoArbitrary a => CoArbitrary (NonEmpty a) where
+  coarbitrary = coarbitrary . toList


### PR DESCRIPTION
Also add Test.QuickCheck.Instances.NonEmpty.

Since this changes the signature of `semigroup`, this is a breaking change.

----

@conal If you approve of this change, maybe wait with cutting a release. `monoid` and possibly other batches could be completed too.

