### PR TITLE
Add notes on monadFunctor and monadApplicative

### DIFF
--- a/src/Test/QuickCheck/Classes.hs
+++ b/src/Test/QuickCheck/Classes.hs
@@ -465,6 +465,9 @@ monad = const ( "monad laws"
    apP f x = (f <*> x) =-= (f `ap` x)
 
 -- | Law for monads that are also instances of 'Functor'.
+--
+-- Note that instances that satisfy 'applicative' and 'monad'
+-- are implied to satisfy this property too.
 monadFunctor :: forall m a b.
                 ( Monad m
                 , Arbitrary b, CoArbitrary a
@@ -476,6 +479,7 @@ monadFunctor = const ( "monad functor"
    bindReturnP :: (a -> b) -> m a -> Property
    bindReturnP f xs = fmap f xs =-= (xs >>= return . f)
 
+-- | Note that 'monad' also contains these properties.
 monadApplicative :: forall m a b.
                     ( Monad m
                     , EqProp (m a), EqProp (m b)


### PR DESCRIPTION
I think this might be better than deprecating them. Possible usecases for these functions are when your instances aren't fully legal but you still want to check relationships between instances.