### PR TITLE
Clean up some warnings

### DIFF
--- a/src/Test/QuickCheck/Checkers.hs
+++ b/src/Test/QuickCheck/Checkers.hs
@@ -44,7 +44,6 @@ module Test.QuickCheck.Checkers
   ) where
 
 import Data.Function (on)
-import Data.Monoid (Monoid (mempty, mappend))
 import Control.Applicative
 import Control.Arrow ((***),first)
 import qualified Control.Exception as Ex

--- a/src/Test/QuickCheck/Classes.hs
+++ b/src/Test/QuickCheck/Classes.hs
@@ -2,12 +2,6 @@
            , Rank2Types, TypeOperators, CPP
   #-}
 
-{-# OPTIONS_GHC -Wall #-}
-
-#if MIN_VERSION_base(4,9,0)
--- https://github.com/conal/checkers/pull/38
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
-#endif
 ----------------------------------------------------------------------
 -- |
 -- Module      :  Test.QuickCheck.Classes
@@ -34,7 +28,6 @@ module Test.QuickCheck.Classes
   )
   where
 
-import Control.Applicative ((<$>))
 import Data.Foldable (Foldable(..))
 import Data.Functor.Apply (Apply ((<.>)))
 import Data.Functor.Alt (Alt ((<!>)))
@@ -42,9 +35,9 @@ import Data.Functor.Bind (Bind ((>>-)), apDefault)
 import qualified Data.Functor.Bind as B (Bind (join))
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Semigroup (Semigroup (..))
-import Data.Monoid (Monoid (mappend, mempty), Endo(..), Dual(..), Sum(..), Product(..))
-import Data.Traversable (Traversable (..), fmapDefault, foldMapDefault)
-import Control.Applicative
+import Data.Monoid (Endo(..), Dual(..), Sum(..), Product(..))
+import Data.Traversable (fmapDefault, foldMapDefault)
+import Control.Applicative (Alternative(..))
 import Control.Monad (MonadPlus (..), ap, join)
 import Control.Arrow (Arrow,ArrowChoice,first,second,left,right,(>>>),arr)
 import Test.QuickCheck
@@ -745,6 +738,9 @@ traversable = const ( "traversable"
 -- | Note that 'foldable' doesn't check the strictness of 'foldl'', `foldr'' and `foldMap''.
 --
 -- @since 0.4.13
+
+-- The (Arbitrary m) constraint is required with base >= 4.13, where we have an
+-- additional property for checking foldMap'.
 foldable :: forall t a b m n o.
             ( Foldable t
             , CoArbitrary a, CoArbitrary b

--- a/src/Test/QuickCheck/Instances/Array.hs
+++ b/src/Test/QuickCheck/Instances/Array.hs
@@ -10,6 +10,7 @@ module Test.QuickCheck.Instances.Array where
 import Test.QuickCheck
 import Data.Array
 
+-- The redundant (Ix a) constraint is required with GHC-7.10.
 instance (Ix a, Integral a, Arbitrary b) => Arbitrary (Array a b) where
   arbitrary   =
     (\x -> listArray (0,fromIntegral (length x - 1)) x) <$> arbitrary

--- a/src/Test/QuickCheck/Instances/Maybe.hs
+++ b/src/Test/QuickCheck/Instances/Maybe.hs
@@ -1,6 +1,5 @@
 module Test.QuickCheck.Instances.Maybe (maybeGen) where
 
-import Control.Applicative (pure, (<$>))
 import Test.QuickCheck
 
 maybeGen :: Gen a -> Gen (Maybe a)

--- a/src/Test/QuickCheck/Instances/Num.hs
+++ b/src/Test/QuickCheck/Instances/Num.hs
@@ -4,7 +4,6 @@ module Test.QuickCheck.Instances.Num
        ,nonZero,nonZero_
        ) where
 
-import Control.Applicative ((<$>))
 import Test.QuickCheck
 import Control.Monad.Extensions
 


### PR DESCRIPTION
* Get rid of some redundant import warnings

* Don't disable redundant-constraint warning that doesn't appear for
  GHC >= 8.8.

* Remove a redundant -Wall

* Add comments explaining warnings