### PR TITLE
Fix 8.10

### DIFF
--- a/src/Test/QuickCheck/Checkers.hs
+++ b/src/Test/QuickCheck/Checkers.hs
@@ -50,11 +50,7 @@ import Control.Arrow ((***),first)
 import qualified Control.Exception as Ex
 import Data.List (foldl')
 import Data.List.NonEmpty (NonEmpty (..))
-import Data.Monoid hiding (
-#if __GLASGOW_HASKELL__ < 810
-    First, Last
-#endif
-                          )
+import Data.Monoid hiding (First, Last)
 
 import Data.Complex
 import Data.Proxy


### PR DESCRIPTION
According to https://gitlab.haskell.org/ghc/ghc/issues/15028, the promised deletions in 8.10 didn't occur, and thus break checkers' build on 8.10. This fixes it!

I'll also follow up with a travis change.

Fixes #44

@sjakobi 